### PR TITLE
Add missing [compat] entries to fix Aqua deps_compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,14 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 VectorizedRNGStaticArraysExt = ["StaticArraysCore"]
 
 [compat]
+Distributed = "1"
+RNGTest = "1"
+Random = "1"
 Requires = "1"
 SLEEFPirates = "0.6.29"
+StaticArrays = "1"
 StaticArraysCore = "1"
+Test = "1"
 UnPack = "1"
 VectorizationBase = "0.19.38, 0.20.1, 0.21"
 julia = "1.6"


### PR DESCRIPTION
## Summary

`Aqua.test_deps_compat(VectorizedRNG)` fails on current CI because several deps in `[deps]` (stdlibs) and `[extras]` lack `[compat]` entries:

- `Distributed` (stdlib, `[deps]`)
- `Random` (stdlib, `[deps]`)
- `Test`, `RNGTest`, `StaticArrays` ([extras])

Add `"1"` compat for each (RNGTest only has 1.x in the General registry).

This is the same kind of pre-existing Aqua hygiene failure that's been failing the VectorizationBase.jl downstream `VectorizedRNG.jl/Interface/{1,lts,pre}` jobs for a while. Posting separately so the macOS-ARM grant work I'm doing in JuliaSIMD/VectorizationBase.jl#127 / #128 doesn't get tangled up with it.

## Test plan

- [x] `Aqua.test_deps_compat(VectorizedRNG)` passes locally.
- [x] `Aqua.test_all(VectorizedRNG)` passes all checks: ambiguities, unbound type params, undefined exports, project_extras vs test/Project.toml, stale deps, compat (4), piracies, persistent tasks.
- [ ] CI green on the downstream Interface check in JuliaSIMD/VectorizationBase.jl#127 / #128 once this is merged + tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)